### PR TITLE
InstrumentationTest should always return true

### DIFF
--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/InstrumentationTest.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/InstrumentationTest.groovy
@@ -25,4 +25,7 @@ class InstrumentationTest extends ConfiguredTest implements TestPackageProvider,
         this.testPackageUploadType = UploadType.INSTRUMENTATION_TEST_PACKAGE
     }
 
+    @Override
+    boolean isValid() { return true }
+
 }


### PR DESCRIPTION
Because `app-debug-androidTest-unaligned.apk` will be automatically generated and passed to `uploadApks`.