### PR TITLE
Make run name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Building the plugin is optional.  The plugin is published through Maven Central.
         
         devicePool "My Device Pool Name" // optional: Defaults to "Top Devices"
         
+        runName "My Run" // optional: Defaults to "${appName}-${buildVariant}.apk (Gradle)"
+        
         useUnmeteredDevices() // optional if you wish to use your un-metered devices
         
     

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServer.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServer.java
@@ -112,7 +112,7 @@ public class DeviceFarmServer extends TestServer {
                 .withDevicePoolArn(devicePool.getArn())
                 .withProjectArn(project.getArn())
                 .withTest(runTest)
-                .withName(String.format("%s (Gradle)", testedApk.getName()));
+                .withName(extension.getRunName(testedApk));
 
         final ScheduleRunResult response = api.scheduleRun(request);
 

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceFarmExtension.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceFarmExtension.groovy
@@ -33,6 +33,11 @@ class DeviceFarmExtension {
     String devicePool = "Top Devices"
 
     /**
+     * [Optional] Name of Run.
+     */
+    String runName
+
+    /**
      * You must have a subscription to set this to false
      */
     boolean metered = true
@@ -79,6 +84,10 @@ class DeviceFarmExtension {
         projectName != null &&
         authentication.valid &&
         test != null && test.valid
+    }
+
+    String getRunName(final File testedApk) {
+        runName ?: "${testedApk.name} (Gradle)"
     }
 
     void useMeteredDevices() {
@@ -134,5 +143,4 @@ class DeviceFarmExtension {
         test = appExplorerTest
 
     }
-
 }

--- a/aws-devicefarm-gradle-plugin/src/test/groovy/com/amazonaws/devicefarm/DeviceFarmPluginTest.java
+++ b/aws-devicefarm-gradle-plugin/src/test/groovy/com/amazonaws/devicefarm/DeviceFarmPluginTest.java
@@ -77,6 +77,7 @@ public class DeviceFarmPluginTest {
 
         DeviceFarmExtension extension = new DeviceFarmExtension(gradleProject);
         extension.setProjectName("MyProject");
+        extension.setRunName("MyRun");
 
         DeviceFarmServer server = new DeviceFarmServer(extension, loggerMock, apiMock, uploaderMock, new DeviceFarmUtils(apiMock, extension));
 
@@ -112,7 +113,7 @@ public class DeviceFarmPluginTest {
             apiMock.scheduleRun(runRequest = withCapture());
             assertNotNull(runRequest);
             assertEquals(runRequest.getTest().getType(), TestType.INSTRUMENTATION.toString());
-
+            assertEquals(runRequest.getName(), "MyRun");
 
         }};
 


### PR DESCRIPTION
If this pull request is merged, we can set the name of run.
Though we leave `runName` as blank, `app-debug.apk (Gradle)` is used as default name.
