### PR TITLE
Fix Radio States causing MissingPropertyException

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Building the plugin is optional.  The plugin is published through Maven Central.
  
             extraDataZipFile file("relative/path/to/zip") // default null
             auxiliaryApps [file("path1"), file("path2")] // default empty list
-            wifi on
-            bluetooth off
-            gps off
-            nfc on
+            wifi “on”
+            bluetooth ”off”
+            gps ”off”
+            nfc ”on”
             latitude 47.6204 // default
             longitude -122.3491 // default
         }

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Building the plugin is optional.  The plugin is published through Maven Central.
  
             extraDataZipFile file("relative/path/to/zip") // default null
             auxiliaryApps [file("path1"), file("path2")] // default empty list
-            wifi “on”
-            bluetooth ”off”
-            gps ”off”
-            nfc ”on”
+            wifi "on"
+            bluetooth "off"
+            gps "off"
+            nfc "on"
             latitude 47.6204 // default
             longitude -122.3491 // default
         }

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceState.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceState.groovy
@@ -38,10 +38,10 @@ class DeviceState {
     //These methods make the '=' optional when configuring the plugin
     void extraDataZipFile(File val) { extraDataZipFile = val }
     void auxiliaryApps(List<File> val) { auxiliaryApps = val }
-    void wifi(RadioOnOff b) { wifiOn = b.bool }
-    void bluetooth(RadioOnOff b) { bluetoothOn = b.bool }
-    void gps(RadioOnOff b) { gpsOn = b.bool }
-    void nfc(RadioOnOff b) { nfcOn = b.bool }
+    void wifi(String onOff) { wifiOn = RadioOnOff.valueOf(onOff).bool}
+    void bluetooth(String onOff) { bluetoothOn = RadioOnOff.valueOf(onOff).bool}
+    void gps(String onOff) { gpsOn = RadioOnOff.valueOf(onOff).bool}
+    void nfc(String onOff) { nfcOn = RadioOnOff.valueOf(onOff).bool}
     void latitude(double d) { latitude = d }
     void longitude(double d) { longitude = d }
 


### PR DESCRIPTION
This will prevent:

* What went wrong:
A problem occurred evaluating project ':app'.
> No such property: on for class: com.amazonaws.devicefarm.extension.DeviceState

Caused by: groovy.lang.MissingPropertyException: No such property: on for class: com.amazonaws.devicefarm.extension.DeviceState