### PR TITLE
Java 7 Support and Fixing Auxiliary App Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,13 @@ CHANGELOG
 This CHANGELOG.md file is meant to be a human-readable summary of the changes in each
 tagged version. There should be one entry for each tagged release of the plugin.
 
-### 1.0-SNAPSHOT
-* [lricardo@amazon.com] First release.
+### 1.2 (2015-12-21) [michael-b-willingham]
+* Backwards compatibility with java 7
+* Fix auxiliary apps ‘cannot cast object’ error.
+
+### 1.1 (2015-12-09) [michael-b-willingham]
+* Fix "AWS Device Farm configuration is NOT VALID" (issue 4)
+* Fix device state radio error: "No such property: on for class: com.amazonaws.devicefarm.extension.DeviceState"
+
+### 1.0 (2015-09-23) [lricardo@amazon.com]
+* First release.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Building the plugin is optional.  The plugin is published through Maven Central.
         // optional block, radios default to 'on' state, all parameters optional
         devicestate {
  
-            extraDataZipFile file("relative/path/to/zip") // default null
-            auxiliaryApps [file("path1"), file("path2")] // default empty list
+            extraDataZipFile file("path/to/zip") // or ‘null’ if you have no extra data. Default is null.
+            auxiliaryApps files(file("path/to/app"), file("path/to/app2")) // or ‘files()’ if you have no auxiliary apps. Default is an empty list.
             wifi "on"
             bluetooth "off"
             gps "off"
@@ -248,7 +248,7 @@ Dependencies
 
 Java SDK (Android Studio Project)
 --------
-* Java 7
+* Java 7 or higher
 
 
 Runtime (Include these in your build.gradle)

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Building the plugin is optional.  The plugin is published through Maven Central.
         
         dependencies {        
             classpath 'com.android.tools.build:gradle:1.3.0'           
-            classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.1'
+            classpath 'com.amazonaws:aws-devicefarm-gradle-plugin:1.2'
         }        
     }
 ```
 
-2. Configure the plugin in your build.gradle file. See below for test specific configuration.
+2. Configure the plugin in your module’s build.gradle file. See below for test specific configuration.
 
 ```
     apply plugin: 'devicefarm'
@@ -245,15 +245,21 @@ As Device Farm supports additional test types the plugin must be extended to ena
 Dependencies
 ============
 
-Runtime
--------
+
+Java SDK (Android Studio Project)
+--------
+* Java 7
+
+
+Runtime (Include these in your build.gradle)
+--------------------------------------------
 
 * AWS SDK 1.10.15 or later.
 * Android tools builder test api 0.5.2
 * Apache Commons Lang3 3.3.4
 
-For Unit tests
---------------
+For Unit tests (Include these in your build.gradle)
+---------------------------------------------------
  
 * Testng 6.8.8
 * Jmockit 1.19

--- a/aws-devicefarm-gradle-plugin/build.gradle
+++ b/aws-devicefarm-gradle-plugin/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'idea'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-sourceCompatibility = '8'
-targetCompatibility = '8'
+sourceCompatibility = '7'
+targetCompatibility = '7'
 
 repositories {
     mavenCentral()
@@ -50,7 +50,7 @@ test {
 }
 
 group 'com.amazonaws'
-version '1.1'
+version '1.2'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServer.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServer.java
@@ -184,7 +184,7 @@ public class DeviceFarmServer extends TestServer {
     private List<String> getAuxAppArns(Collection<Upload> auxUploads) {
         List<String> auxAppArns = Lists.newArrayList();
 
-        if (auxAppArns == null || auxAppArns.size() == 0) {
+        if (auxUploads == null || auxUploads.size() == 0) {
            return auxAppArns;
         }
 

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceState.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceState.groovy
@@ -17,6 +17,7 @@ package com.amazonaws.devicefarm.extension
 
 import com.amazonaws.services.devicefarm.model.Location
 import com.amazonaws.services.devicefarm.model.Radios
+import org.gradle.api.file.FileCollection
 
 /**
  * DeviceState parameters
@@ -37,7 +38,7 @@ class DeviceState {
 
     //These methods make the '=' optional when configuring the plugin
     void extraDataZipFile(File val) { extraDataZipFile = val }
-    void auxiliaryApps(List<File> val) { auxiliaryApps = val }
+    void auxiliaryApps(FileCollection val) { auxiliaryApps = val as List }
     void wifi(String onOff) { wifiOn = RadioOnOff.valueOf(onOff).bool}
     void bluetooth(String onOff) { bluetoothOn = RadioOnOff.valueOf(onOff).bool}
     void gps(String onOff) { gpsOn = RadioOnOff.valueOf(onOff).bool}

--- a/aws-devicefarm-gradle-plugin/src/test/groovy/com/amazonaws/devicefarm/DeviceFarmPluginTest.java
+++ b/aws-devicefarm-gradle-plugin/src/test/groovy/com/amazonaws/devicefarm/DeviceFarmPluginTest.java
@@ -15,14 +15,12 @@
  */
 package com.amazonaws.devicefarm;
 
-import com.amazonaws.devicefarm.extension.Authentication;
 import com.amazonaws.devicefarm.extension.DeviceFarmExtension;
 import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
 import com.amazonaws.services.devicefarm.model.*;
 import com.android.build.gradle.AppExtension;
 import mockit.Expectations;
 import mockit.Injectable;
-import mockit.Mocked;
 import mockit.Verifications;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -65,14 +63,14 @@ public class DeviceFarmPluginTest {
     @Test
     public void instrumentationTest(@Injectable File testPackage, @Injectable File testedApp) throws IOException {
 
-        ListProjectsResult projectList = new ListProjectsResult();
-        com.amazonaws.services.devicefarm.model.Project myProject = new com.amazonaws.services.devicefarm.model.Project()
+        final ListProjectsResult projectList = new ListProjectsResult();
+        final com.amazonaws.services.devicefarm.model.Project myProject = new com.amazonaws.services.devicefarm.model.Project()
                 .withName("MyProject")
                 .withArn("1234");
 
         projectList.setProjects(Arrays.asList(myProject));
 
-        ListDevicePoolsResult devicePoolList = new ListDevicePoolsResult();
+        final ListDevicePoolsResult devicePoolList = new ListDevicePoolsResult();
         devicePoolList.setDevicePools(Arrays.asList(new DevicePool().withName("Top Devices").withArn("1234")));
 
         DeviceFarmExtension extension = new DeviceFarmExtension(gradleProject);
@@ -80,7 +78,7 @@ public class DeviceFarmPluginTest {
 
         DeviceFarmServer server = new DeviceFarmServer(extension, loggerMock, apiMock, uploaderMock, new DeviceFarmUtils(apiMock, extension));
 
-        ScheduleRunResult runResult = new ScheduleRunResult();
+        final ScheduleRunResult runResult = new ScheduleRunResult();
         runResult.setRun(new Run());
         runResult.getRun().setArn("arn:1:2:3:4:5:runarn/projarn");
 


### PR DESCRIPTION
1. Code changes to allow plugin to be compiled and used by Java 7 SDK.
2. Fix "Cannot cast object" error when using auxiliary apps. 
