### PR TITLE
Use the roleArn if it exists

### DIFF
--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
@@ -15,7 +15,8 @@
 package com.amazonaws.devicefarm;
 
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.devicefarm.extension.DeviceFarmExtension;
 import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
@@ -41,19 +42,18 @@ public class DeviceFarmClientFactory {
 
         final String roleArn = extension.getAuthentication().getRoleArn();
 
-        AWSCredentials credentials = extension.getAuthentication();
+        AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(extension.getAuthentication());
 
         if (roleArn != null) {
-            final STSAssumeRoleSessionCredentialsProvider sts = new STSAssumeRoleSessionCredentialsProvider
+            credentialsProvider = new STSAssumeRoleSessionCredentialsProvider
                     .Builder(roleArn, RandomStringUtils.randomAlphanumeric(8))
                     .build();
-            credentials = sts.getCredentials();
         }
 
         final ClientConfiguration clientConfiguration = new ClientConfiguration()
                 .withUserAgent(String.format(extension.getUserAgent(), pluginVersion));
 
-        AWSDeviceFarmClient apiClient = new AWSDeviceFarmClient(credentials, clientConfiguration);
+        AWSDeviceFarmClient apiClient = new AWSDeviceFarmClient(credentialsProvider, clientConfiguration);
         apiClient.setServiceNameIntern("devicefarm");
         if (extension.getEndpointOverride() != null) {
             apiClient.setEndpoint(extension.getEndpointOverride());

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmPlugin.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmPlugin.groovy
@@ -35,6 +35,6 @@ class DeviceFarmPlugin implements Plugin<Project> {
 
         project.android.testServer(
                 new DeviceFarmServer(extension, project.android.logger,
-                        new DeviceFarmClientFactory(project.android.logger).initializeApiClient(extension)))
+                        new DeviceFarmServerDependenciesImpl(extension, project.android.logger)))
     }
 }

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServerDependencies.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServerDependencies.java
@@ -1,0 +1,12 @@
+package com.amazonaws.devicefarm;
+
+import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
+
+public interface DeviceFarmServerDependencies {
+
+    AWSDeviceFarmClient createDeviceFarmClient();
+
+    DeviceFarmUploader createDeviceFarmUploader(AWSDeviceFarmClient client);
+
+    DeviceFarmUtils createDeviceFarmUtils(AWSDeviceFarmClient client);
+}

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServerDependenciesImpl.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServerDependenciesImpl.java
@@ -1,0 +1,35 @@
+package com.amazonaws.devicefarm;
+
+import com.amazonaws.devicefarm.extension.DeviceFarmExtension;
+import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
+import org.gradle.api.logging.Logger;
+
+public class DeviceFarmServerDependenciesImpl implements DeviceFarmServerDependencies {
+
+    private final DeviceFarmExtension extension;
+
+    private final Logger logger;
+
+    private final DeviceFarmClientFactory deviceFarmClientFactory;
+
+    public DeviceFarmServerDependenciesImpl(DeviceFarmExtension extension, Logger logger) {
+        this.extension = extension;
+        this.logger = logger;
+        this.deviceFarmClientFactory = new DeviceFarmClientFactory(logger);
+    }
+
+    @Override
+    public AWSDeviceFarmClient createDeviceFarmClient() {
+        return deviceFarmClientFactory.initializeApiClient(extension);
+    }
+
+    @Override
+    public DeviceFarmUploader createDeviceFarmUploader(AWSDeviceFarmClient client) {
+        return new DeviceFarmUploader(client, logger);
+    }
+
+    @Override
+    public DeviceFarmUtils createDeviceFarmUtils(AWSDeviceFarmClient client) {
+        return new DeviceFarmUtils(client, extension);
+    }
+}

--- a/aws-devicefarm-gradle-plugin/src/test/groovy/com/amazonaws/devicefarm/DeviceFarmPluginTest.java
+++ b/aws-devicefarm-gradle-plugin/src/test/groovy/com/amazonaws/devicefarm/DeviceFarmPluginTest.java
@@ -15,7 +15,6 @@
 package com.amazonaws.devicefarm;
 
 import com.amazonaws.devicefarm.extension.DeviceFarmExtension;
-import com.amazonaws.services.devicefarm.AWSDeviceFarm;
 import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
 import com.amazonaws.services.devicefarm.model.*;
 import com.android.build.gradle.AppExtension;
@@ -39,7 +38,7 @@ import static org.testng.AssertJUnit.assertTrue;
 public class DeviceFarmPluginTest {
 
     @Injectable
-    AWSDeviceFarm apiMock;
+    AWSDeviceFarmClient apiMock;
 
     @Injectable
     DeviceFarmUploader uploaderMock;
@@ -76,7 +75,7 @@ public class DeviceFarmPluginTest {
         DeviceFarmExtension extension = new DeviceFarmExtension(gradleProject);
         extension.setProjectName("MyProject");
 
-        DeviceFarmServer server = new DeviceFarmServer(extension, loggerMock, apiMock, uploaderMock, new DeviceFarmUtils(apiMock, extension));
+        DeviceFarmServer server = new DeviceFarmServer(extension, loggerMock, new DeviceFarmServerDependenciesMock(extension));
 
         final ScheduleRunResult runResult = new ScheduleRunResult();
         runResult.setRun(new Run());
@@ -118,4 +117,27 @@ public class DeviceFarmPluginTest {
 
     }
 
+    private class DeviceFarmServerDependenciesMock implements DeviceFarmServerDependencies {
+
+        private DeviceFarmExtension extension;
+
+        DeviceFarmServerDependenciesMock(DeviceFarmExtension extension) {
+            this.extension = extension;
+        }
+
+        @Override
+        public AWSDeviceFarmClient createDeviceFarmClient() {
+            return apiMock;
+        }
+
+        @Override
+        public DeviceFarmUploader createDeviceFarmUploader(AWSDeviceFarmClient client) {
+            return uploaderMock;
+        }
+
+        @Override
+        public DeviceFarmUtils createDeviceFarmUtils(AWSDeviceFarmClient client) {
+            return new DeviceFarmUtils(apiMock, extension);
+        }
+    }
 }


### PR DESCRIPTION
The extension object isn't populated with user-defined data until
uploadApks() is called.

DeviceFarmPluginFactory.initializeApiClient(extension) was called
before the extension object was populated, always resulting in an empty
roleArn.

DeviceFarmServer construction is now delayed until uploadApks() is
called. This is done using DeviceFarmServerDependencies.