### PR TITLE
Added support for appium ruby and appium node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,18 +170,20 @@ Appium
 * [Appium JUnit](http://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-android-appium-java-junit.html)
 * [Appium TestNG](http://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-android-appium-java-testng.html)
 * [Appium Python](http://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-android-appium-python.html)
+* [Appium Ruby](http://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-android-appium-ruby.html)
+* [Appium Node.js](http://docs.aws.amazon.com/devicefarm/latest/developerguide/test-types-android-appium-node.html)
 
-Device Farm provides support for Appium Java TestNG , Appium Java JUnit and Appium Java python for Android.
+Device Farm provides support for Appium Java TestNG , Appium Java JUnit, Appium python, Appium Node.js and Appium Ruby for Android.
 
-You can choose to `useTestNG()` or `useJUnit()` or  `usePython()`.
+You can choose to `useTestNG()` or `useJUnit()` or  `usePython()` or `useNode()`` or `useRuby()`.
 
 JUnit is the default and does not need to be explicitly specified.
 
 ```gradle
 appium {
     tests file("path to zip file") // Required
-    useTestNG() // or useJUnit() or usePython()
-    testSpecName "My Test Spec Name" // if you want to use Custom Mode // Optional
+    useTestNG() // or useJUnit() or usePython() or useNode() or useRuby()
+    testSpecName "My Test Spec Name" // if you want to use Custom Mode // Optional for TestNG, JUnit and Python
 }
 ```
 

--- a/aws-devicefarm-gradle-plugin/build.gradle
+++ b/aws-devicefarm-gradle-plugin/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     compile 'com.android.tools.build:builder-test-api:0.5.2'
     compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.amazonaws:aws-java-sdk:1.11.408'
+    compile 'com.amazonaws:aws-java-sdk:1.11.481'
     testCompile 'org.testng:testng:6.8.8'
     testCompile 'com.android.tools.build:gradle:3.0.0'
     testCompile 'org.jmockit:jmockit:1.19'

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/AppiumTest.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/AppiumTest.groovy
@@ -51,6 +51,22 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
         this.testPackageUploadType = UploadType.APPIUM_PYTHON_TEST_PACKAGE
     }
 
+    /**
+     * Configure for Ruby
+     */
+    void useRuby() {
+        testType = TestType.APPIUM_RUBY
+        this.testPackageUploadType = UploadType.APPIUM_RUBY_TEST_PACKAGE
+    }
+
+    /**
+     * Configure for Node.js
+     */
+    void useNode() {
+        testType = TestType.APPIUM_NODE
+        this.testPackageUploadType = UploadType.APPIUM_NODE_TEST_PACKAGE
+    }
+
     @Override
     boolean isValid() { TestPackageProvider.super.isValid() }
 


### PR DESCRIPTION
Tested with the android sample app

appium {
        tests file("/Users/anuragg/Desktop/Kanapka/RawMode/Testpackages/android/node/appium-node.zip") // Required
        useNode() // or useJUnit() or usePython()
        testSpecName "android.yml" // if you want to use Custom Mode // Optional
        }
appium {
        tests file("/Users/anuragg/Desktop/Kanapka/RawMode/Testpackages/android/ruby/appium-ruby.zip") // Required
        useRuby() // or useJUnit() or usePython()
        te