### PR TITLE
changes to support test sharding of test cases across devices in a device pool

### DIFF
--- a/aws-devicefarm-gradle-plugin/build.gradle
+++ b/aws-devicefarm-gradle-plugin/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     compile 'com.android.tools.build:builder-test-api:0.5.2'
     compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.amazonaws:aws-java-sdk:1.11.481'
+    compile 'com.amazonaws:aws-java-sdk:1.11.753'
     testCompile 'org.testng:testng:6.8.8'
     testCompile 'com.android.tools.build:gradle:3.0.0'
     testCompile 'org.jmockit:jmockit:1.19'
@@ -49,7 +49,7 @@ test {
 }
 
 group 'com.amazonaws'
-version '1.4'
+version '1.5'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
@@ -51,7 +51,6 @@ public class DeviceFarmClientFactory {
                 .withUserAgentSuffix(String.format(extension.getUserAgent(), pluginVersion));
         return clientBuilder.withCredentials(credentialsProvider)
                             .withClientConfiguration(clientConfiguration)
-                            .withRegion("us-west-2")
                             .build();
     }
 

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
@@ -15,10 +15,16 @@
 package com.amazonaws.devicefarm;
 
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.STSSessionCredentialsProvider;
+import com.amazonaws.devicefarm.extension.Authentication;
 import com.amazonaws.devicefarm.extension.DeviceFarmExtension;
-import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
+import com.amazonaws.services.devicefarm.AWSDeviceFarm;
+import com.amazonaws.services.devicefarm.AWSDeviceFarmClientBuilder;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.gradle.api.logging.Logger;
 
@@ -30,37 +36,23 @@ import java.util.Properties;
  */
 public class DeviceFarmClientFactory {
 
-    final String pluginVersion;
+    private final String pluginVersion;
 
     public DeviceFarmClientFactory(final Logger logger) {
         this.pluginVersion = readPluginVersion();
         logger.lifecycle("AWS Device Farm Plugin version " + pluginVersion);
     }
 
-    public AWSDeviceFarmClient initializeApiClient(final DeviceFarmExtension extension) {
-
-        final String roleArn = extension.getAuthentication().getRoleArn();
-
-        AWSCredentials credentials = extension.getAuthentication();
-
-        if (roleArn != null) {
-            final STSAssumeRoleSessionCredentialsProvider sts = new STSAssumeRoleSessionCredentialsProvider
-                    .Builder(roleArn, RandomStringUtils.randomAlphanumeric(8))
-                    .build();
-            credentials = sts.getCredentials();
-        }
-
+    public AWSDeviceFarm initializeApiClient(final DeviceFarmExtension extension) {
+        final AWSDeviceFarmClientBuilder clientBuilder = AWSDeviceFarmClientBuilder.standard();
+        final Authentication authentication = extension.getAuthentication();
+        final AWSCredentialsProvider credentialsProvider = getAwsCredentialsProvider(authentication);
         final ClientConfiguration clientConfiguration = new ClientConfiguration()
-                .withUserAgent(String.format(extension.getUserAgent(), pluginVersion));
-
-        AWSDeviceFarmClient apiClient = new AWSDeviceFarmClient(credentials, clientConfiguration);
-        apiClient.setServiceNameIntern("devicefarm");
-        if (extension.getEndpointOverride() != null) {
-            apiClient.setEndpoint(extension.getEndpointOverride());
-        }
-
-        return apiClient;
-
+                .withUserAgentSuffix(String.format(extension.getUserAgent(), pluginVersion));
+        return clientBuilder.withCredentials(credentialsProvider)
+                            .withClientConfiguration(clientConfiguration)
+                            .withRegion("us-west-2")
+                            .build();
     }
 
     private static String readPluginVersion() {
@@ -75,5 +67,22 @@ public class DeviceFarmClientFactory {
         }
     }
 
+    private AWSCredentialsProvider getAwsCredentialsProvider(Authentication authentication) {
+        AWSCredentialsProvider credentialsProvider;
+        if (authentication != null && authentication.isValid()) {
+            if (authentication.getRoleArn() != null) {
+                credentialsProvider = new STSAssumeRoleSessionCredentialsProvider
+                        .Builder(authentication.getRoleArn(), RandomStringUtils.randomAlphanumeric(8))
+                        .build();
+            } else {
+                BasicAWSCredentials credentials = new BasicAWSCredentials(authentication.getAccessKey(), authentication.getSecretKey());
+                credentialsProvider = new STSSessionCredentialsProvider(credentials);
+            }
+        } else {
+            credentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
+        }
+        return credentialsProvider;
+    }
 
+    
 }

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmClientFactory.java
@@ -15,10 +15,16 @@
 package com.amazonaws.devicefarm;
 
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.STSSessionCredentialsProvider;
+import com.amazonaws.devicefarm.extension.Authentication;
 import com.amazonaws.devicefarm.extension.DeviceFarmExtension;
-import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
+import com.amazonaws.services.devicefarm.AWSDeviceFarm;
+import com.amazonaws.services.devicefarm.AWSDeviceFarmClientBuilder;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.gradle.api.logging.Logger;
 
@@ -30,37 +36,23 @@ import java.util.Properties;
  */
 public class DeviceFarmClientFactory {
 
-    final String pluginVersion;
+    private final String pluginVersion;
 
     public DeviceFarmClientFactory(final Logger logger) {
         this.pluginVersion = readPluginVersion();
         logger.lifecycle("AWS Device Farm Plugin version " + pluginVersion);
     }
 
-    public AWSDeviceFarmClient initializeApiClient(final DeviceFarmExtension extension) {
-
-        final String roleArn = extension.getAuthentication().getRoleArn();
-
-        AWSCredentials credentials = extension.getAuthentication();
-
-        if (roleArn != null) {
-            final STSAssumeRoleSessionCredentialsProvider sts = new STSAssumeRoleSessionCredentialsProvider
-                    .Builder(roleArn, RandomStringUtils.randomAlphanumeric(8))
-                    .build();
-            credentials = sts.getCredentials();
-        }
-
+    public AWSDeviceFarm initializeApiClient(final DeviceFarmExtension extension) {
+        final AWSDeviceFarmClientBuilder clientBuilder = AWSDeviceFarmClientBuilder.standard();
+        final Authentication authentication = extension.getAuthentication();
+        final AWSCredentialsProvider credentialsProvider = getAwsCredentialsProvider(authentication);
         final ClientConfiguration clientConfiguration = new ClientConfiguration()
-                .withUserAgent(String.format(extension.getUserAgent(), pluginVersion));
-
-        AWSDeviceFarmClient apiClient = new AWSDeviceFarmClient(credentials, clientConfiguration);
-        apiClient.setServiceNameIntern("devicefarm");
-        if (extension.getEndpointOverride() != null) {
-            apiClient.setEndpoint(extension.getEndpointOverride());
-        }
-
-        return apiClient;
-
+                .withUserAgentSuffix(String.format(extension.getUserAgent(), pluginVersion));
+        return clientBuilder.withCredentials(credentialsProvider)
+                            .withClientConfiguration(clientConfiguration)
+                            .withRegion("us-west-2")
+                            .build();
     }
 
     private static String readPluginVersion() {
@@ -75,5 +67,20 @@ public class DeviceFarmClientFactory {
         }
     }
 
-
+    private AWSCredentialsProvider getAwsCredentialsProvider(Authentication authentication) {
+        AWSCredentialsProvider credentialsProvider;
+        if (authentication != null && authentication.isValid()) {
+            if (authentication.getRoleArn() != null) {
+                credentialsProvider = new STSAssumeRoleSessionCredentialsProvider
+                        .Builder(authentication.getRoleArn(), RandomStringUtils.randomAlphanumeric(8))
+                        .build();
+            } else {
+                BasicAWSCredentials credentials = new BasicAWSCredentials(authentication.getAccessKey(), authentication.getSecretKey());
+                credentialsProvider = new STSSessionCredentialsProvider(credentials);
+            }
+        } else {
+            credentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
+        }
+        return credentialsProvider;
+    }
 }

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServer.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmServer.java
@@ -19,7 +19,9 @@ import com.amazonaws.devicefarm.extension.TestPackageProvider;
 import com.amazonaws.services.devicefarm.AWSDeviceFarm;
 import com.amazonaws.services.devicefarm.AWSDeviceFarmClient;
 import com.amazonaws.services.devicefarm.model.BillingMethod;
+import com.amazonaws.services.devicefarm.model.DeviceFilter;
 import com.amazonaws.services.devicefarm.model.DevicePool;
+import com.amazonaws.services.devicefarm.model.DeviceSelectionConfiguration;
 import com.amazonaws.services.devicefarm.model.ExecutionConfiguration;
 import com.amazonaws.services.devicefarm.model.Project;
 import com.amazonaws.services.devicefarm.model.ScheduleRunConfiguration;
@@ -34,7 +36,9 @@ import org.gradle.api.logging.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -43,7 +47,10 @@ import java.util.List;
  */
 public class DeviceFarmServer extends TestServer {
 
+    private static final String RUNPARAM_VIDEO_RECORDING = "video_recording";
     private static final String RUNPARAM_APP_PERF_MONITORING = "app_performance_monitoring";
+    private static final String DEVICE_FILTER_ATTRIBUTE = "ARN";
+    private static final String DEVICE_FILTER_OPERATOR = "IN";
 
     private final DeviceFarmExtension extension;
     private final Logger logger;
@@ -95,34 +102,24 @@ public class DeviceFarmServer extends TestServer {
         logger.lifecycle(String.format("Using Project \"%s\", \"%s\"", project.getName(), project.getArn()));
 
         final DevicePool devicePool = utils.findDevicePoolByName(project, extension.getDevicePool());
-        logger.lifecycle(String.format("Using Device Pool \"%s\", \"%s\"", devicePool.getName(), devicePool.getArn()));
+        logger.lifecycle(String.format("Using Device Pool \"%s\", \"%s\"", devicePool.getName(),
+                                       devicePool.getArn()));
 
         final String appArn = uploader.upload(testedApk == null ? testPackage : testedApk, project, UploadType.ANDROID_APP).getArn();
         logger.lifecycle(String.format("Will test app in  \"%s\", \"%s\"", testedApk == null ? testPackage.getName() : testedApk.getName(), appArn));
 
         final Collection<Upload> auxApps = uploadAuxApps(project);
 
+        final Collection<Upload> testSpecs = uploadTestSpec(project);
+
         final String extraDataArn = uploadExtraDataZip(project);
 
-        // For few frameworks , you can specify a testSpec
-        final Upload testSpec = utils.findTestSpecByName(extension.getTest().getTestSpecName(), project);
-        if (testSpec != null) {
-            logger.lifecycle(String.format("Using  TestSpec \"%s\", \"%s\"", testSpec.getName(), testSpec.getArn()));
-        }
-
-        final ScheduleRunTest runTest = new ScheduleRunTest()
-                .withParameters(extension.getTest().getTestParameters())
-                .withType(extension.getTest().getTestType())
-                .withFilter(extension.getTest().getFilter())
-                .withTestPackageArn(uploadTestPackageIfNeeded(project, testPackage))
-                .withTestSpecArn(testSpec == null ? null: testSpec.getArn());
-
-
-        runTest.addParametersEntry(RUNPARAM_APP_PERF_MONITORING, Boolean.toString(extension.getPerformanceMonitoring()));
+        ScheduleRunRequest request;
+        ScheduleRunResult response;
+        ScheduleRunTest runTest;
 
         final ExecutionConfiguration executionConfiguration = new ExecutionConfiguration()
-                .withJobTimeoutMinutes(extension.getExecutionTimeoutMinutes())
-                .withVideoCapture(extension.getVideoRecording());
+                .withJobTimeoutMinutes(extension.getExecutionTimeoutMinutes());
 
         final ScheduleRunConfiguration configuration = new ScheduleRunConfiguration()
                 .withAuxiliaryApps(getAuxAppArns(auxApps))
@@ -131,20 +128,90 @@ public class DeviceFarmServer extends TestServer {
                 .withLocation(extension.getDeviceState().getLocation())
                 .withBillingMethod(extension.isMetered() ? BillingMethod.METERED : BillingMethod.UNMETERED)
                 .withRadios(extension.getDeviceState().getRadios());
+        runTest = runTestInstance(project, testPackage);
 
-        final ScheduleRunRequest request = new ScheduleRunRequest()
+        if (extension.getTestSharding()
+                && !extension.getDevicePool().equalsIgnoreCase("Top Devices")
+                && testSpecs != null) {
+            int device = 0;
+            final String[] devicePools = utils.getDevicesInDevicePool(devicePool);
+            for (Upload testSpec : testSpecs) {
+                final String runName = testSpec.getName().split("\\.")[0];
+                logger.lifecycle(String.format("Test spec name \"%s\" with arn \"%s\"", testSpec.getName(), testSpec.getArn()));
+
+                runTest.withTestSpecArn(testSpec.getArn());
+                request = scheduleRunRequestInstance(appArn, configuration, project.getArn(),
+                                                     runTest, executionConfiguration,
+                                                     testPackage, testedApk, runName);
+
+                final DeviceFilter deviceFilter = getDeviceFilterInstance(DEVICE_FILTER_ATTRIBUTE, DEVICE_FILTER_OPERATOR, Collections.singleton(devicePools[device ++]));
+
+                final DeviceSelectionConfiguration deviceSelectionConfiguration = getDeviceSelectionConfiguration(deviceFilter, 1);
+                request.setDeviceSelectionConfiguration(deviceSelectionConfiguration);
+
+                response = api.scheduleRun(request);
+                logger.lifecycle(String.format("View the %s run in the AWS Device Farm Console: %s", runTest
+                        .getType(), utils.getRunUrlFromArn(response.getRun().getArn())));
+
+                if (device == testSpecs.size()) {
+                    device = 0;
+                }
+            }
+        } else {
+            request = scheduleRunRequestInstance(appArn, configuration, project.getArn(), runTest, executionConfiguration,
+                                                 testPackage, testedApk, extension.getDevicePool());
+            request.withDevicePoolArn(devicePool.getArn());
+            response = api.scheduleRun(request);
+            logger.lifecycle(String.format("View the %s run in the AWS Device Farm Console: %s",
+                                           runTest.getType(), utils.getRunUrlFromArn(response.getRun().getArn())));
+
+        }
+    }
+
+    private DeviceSelectionConfiguration getDeviceSelectionConfiguration(final DeviceFilter deviceFilter, int maxDevices) {
+        return new DeviceSelectionConfiguration()
+        .withFilters(Collections.singleton(deviceFilter))
+        .withMaxDevices(maxDevices);
+    }
+
+
+    private ScheduleRunTest runTestInstance(final Project project, final File testPackage) {
+        ScheduleRunTest runTest = new ScheduleRunTest()
+                .withParameters(extension.getTest().getTestParameters())
+                .withType(extension.getTest().getTestType())
+                .withFilter(extension.getTest().getFilter())
+                .withTestPackageArn(uploadTestPackageIfNeeded(project, testPackage));
+
+        runTest.addParametersEntry(RUNPARAM_VIDEO_RECORDING, Boolean.toString(extension.getVideoRecording()));
+        runTest.addParametersEntry(RUNPARAM_APP_PERF_MONITORING, Boolean.toString(extension.getPerformanceMonitoring()));
+
+        return runTest;
+    }
+
+    private DeviceFilter getDeviceFilterInstance(final String attribute, final String operator,
+                                                 final Collection<String> values) {
+        return new DeviceFilter()
+                .withAttribute(attribute)
+                .withOperator(operator)
+                .withValues(values);
+    }
+
+    private ScheduleRunRequest scheduleRunRequestInstance(final String appArn,
+                                                          final ScheduleRunConfiguration scheduleRunConfiguration,
+                                                          final String projectArn,
+                                                          final ScheduleRunTest scheduleRunTest,
+                                                          final ExecutionConfiguration executionConfiguration,
+                                                          final File testPackage,
+                                                          final File testedApk,
+                                                          final String runName) {
+        return new ScheduleRunRequest()
                 .withAppArn(appArn)
-                .withConfiguration(configuration)
-                .withDevicePoolArn(devicePool.getArn())
-                .withProjectArn(project.getArn())
-                .withTest(runTest)
+                .withProjectArn(projectArn)
+                .withConfiguration(scheduleRunConfiguration)
+                .withTest(scheduleRunTest)
                 .withExecutionConfiguration(executionConfiguration)
-                .withName(String.format("%s (Gradle)", testedApk == null ? testPackage.getName() : testedApk.getName()));
-
-        final ScheduleRunResult response = api.scheduleRun(request);
-
-        logger.lifecycle(String.format("View the %s run in the AWS Device Farm Console: %s",
-                runTest.getType(), utils.getRunUrlFromArn(response.getRun().getArn())));
+                .withName(String.format("%s-%s (Gradle)", runName,
+                                        testedApk == null ? testPackage.getName() : testedApk.getName()));
     }
 
     /**
@@ -172,6 +239,29 @@ public class DeviceFarmServer extends TestServer {
         }
 
         return testArtifactsArn;
+    }
+
+    private Collection<Upload> uploadTestSpec(final Project project) {
+
+        Collection<Upload> testSpecFiles = new ArrayList<>();
+
+        if (extension.getTest() instanceof TestPackageProvider) {
+            final TestPackageProvider testPackageProvider = (TestPackageProvider) extension.getTest();
+            testSpecFiles = uploader.batchUpload(extension.getDeviceState().getTestSpecFiles(),
+                                                                    project,
+                                                                    testPackageProvider.getTestSpecUploadType());
+        }
+
+        if (testSpecFiles == null || testSpecFiles.size() == 0) {
+            return null;
+        }
+
+        for (Upload testSpecFile : testSpecFiles) {
+            logger.lifecycle(String.format("Will upload additional test spec files %s, %s",
+                                           testSpecFile.getName(), testSpecFile.getArn()));
+        }
+
+        return testSpecFiles;
     }
 
     private Collection<Upload> uploadAuxApps(final Project project) {

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmUtils.java
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/DeviceFarmUtils.java
@@ -190,6 +190,19 @@ public class DeviceFarmUtils {
     }
 
     /**
+     * Extract the devices arn from the given device pool and return the array of arns.
+     * @param devicePool in which the tests going to get triggered.
+     * @return array of device arns.
+     */
+    public String[] getDevicesInDevicePool(DevicePool devicePool) {
+        return devicePool.getRules().get(0).getValue()
+                         .replace("[\"","")
+                         .replace("]\"", "")
+                         .replace("\"", "")
+                         .split(",");
+    }
+
+    /**
      * Get the Device Farm run ID from the Device Farm run ARN.
      *
      * @param arn The Device Farm run ARN.

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/AppiumTest.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/AppiumTest.groovy
@@ -25,6 +25,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     {
         testType = TestType.APPIUM_JAVA_JUNIT
         this.testPackageUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_SPEC
     }
 
     /**
@@ -33,6 +34,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useTestNG() {
         testType = TestType.APPIUM_JAVA_TESTNG
         this.testPackageUploadType = UploadType.APPIUM_JAVA_TESTNG_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_JAVA_TESTNG_TEST_SPEC
     }
 
     /**
@@ -41,6 +43,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useJUnit() {
         testType = TestType.APPIUM_JAVA_JUNIT
         this.testPackageUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_SPEC
     }
 
     /**
@@ -49,6 +52,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void usePython() {
         testType = TestType.APPIUM_PYTHON
         this.testPackageUploadType = UploadType.APPIUM_PYTHON_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_PYTHON_TEST_SPEC
     }
 
     /**
@@ -57,6 +61,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useRuby() {
         testType = TestType.APPIUM_RUBY
         this.testPackageUploadType = UploadType.APPIUM_RUBY_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_RUBY_TEST_SPEC
     }
 
     /**
@@ -65,6 +70,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useNode() {
         testType = TestType.APPIUM_NODE
         this.testPackageUploadType = UploadType.APPIUM_NODE_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_NODE_TEST_SPEC
     }
 
     @Override

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/AppiumTest.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/AppiumTest.groovy
@@ -25,6 +25,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     {
         testType = TestType.APPIUM_JAVA_JUNIT
         this.testPackageUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_SPEC
     }
 
     /**
@@ -33,6 +34,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useTestNG() {
         testType = TestType.APPIUM_JAVA_TESTNG
         this.testPackageUploadType = UploadType.APPIUM_JAVA_TESTNG_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_JAVA_TESTNG_TEST_SPEC
     }
 
     /**
@@ -49,6 +51,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void usePython() {
         testType = TestType.APPIUM_PYTHON
         this.testPackageUploadType = UploadType.APPIUM_PYTHON_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_JAVA_JUNIT_TEST_SPEC
     }
 
     /**
@@ -57,6 +60,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useRuby() {
         testType = TestType.APPIUM_RUBY
         this.testPackageUploadType = UploadType.APPIUM_RUBY_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_RUBY_TEST_SPEC
     }
 
     /**
@@ -65,6 +69,7 @@ class AppiumTest extends ConfiguredTest implements TestPackageProvider, CustomMo
     void useNode() {
         testType = TestType.APPIUM_NODE
         this.testPackageUploadType = UploadType.APPIUM_NODE_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.APPIUM_NODE_TEST_SPEC
     }
 
     @Override

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceFarmExtension.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceFarmExtension.groovy
@@ -85,6 +85,12 @@ class DeviceFarmExtension {
      */
     ConfiguredTest test = new InstrumentationTest();
 
+    /**
+    * This property will be used to shard the tests across devices
+    */
+    boolean testSharding = false
+
+
     DeviceFarmExtension(final Project project) {
         this.project = project;
     }

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceFarmExtension.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceFarmExtension.groovy
@@ -70,6 +70,11 @@ class DeviceFarmExtension {
     boolean performanceMonitoring = true
 
     /**
+     * Split test cases across device pool devices
+     */
+    boolean testShardingEnabled = false
+
+    /**
      * Authentication credentials
      */
     Authentication authentication = new Authentication();

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceState.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/DeviceState.groovy
@@ -25,6 +25,7 @@ class DeviceState {
 
     File extraDataZipFile
     List<File> auxiliaryApps = Collections.emptyList()
+    List<File> testSpecFiles = Collections.emptyList()
     def wifiOn = true;
     def bluetoothOn = true;
     def gpsOn = true;
@@ -39,6 +40,8 @@ class DeviceState {
     void extraDataZipFile(File val) { extraDataZipFile = val }
 
     void auxiliaryApps(FileCollection val) { auxiliaryApps = val as List }
+
+    void testSpecFiles(FileCollection val) { testSpecFiles = val as List }
 
     void wifi(String onOff) { wifiOn = OnOffConfiguration.valueOf(onOff).bool }
 

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/InstrumentationTest.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/InstrumentationTest.groovy
@@ -22,6 +22,7 @@ class InstrumentationTest extends ConfiguredTest implements TestPackageProvider,
     {
         testType = TestType.INSTRUMENTATION
         this.testPackageUploadType = UploadType.INSTRUMENTATION_TEST_PACKAGE
+        this.testSpecUploadType = UploadType.INSTRUMENTATION_TEST_SPEC
     }
 
     @Override

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/TestPackageProvider.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/TestPackageProvider.groovy
@@ -27,6 +27,11 @@ trait TestPackageProvider {
      */
     UploadType testPackageUploadType
 
+    /**
+    * returns the upload type for the test spec file
+    */
+    UploadType testSpecUploadType
+
     File testPackage = null
 
     void tests(File val) { testPackage = val }
@@ -38,7 +43,6 @@ trait TestPackageProvider {
      * @return the test Apk
      */
     File resolveTestPackage(File defaultTestPackage) { testPackage ?: defaultTestPackage }
-
 
     boolean isValid() {
         testPackage != null && testPackage.canRead()

--- a/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/TestPackageProvider.groovy
+++ b/aws-devicefarm-gradle-plugin/src/main/groovy/com.amazonaws.devicefarm/extension/TestPackageProvider.groovy
@@ -27,6 +27,11 @@ trait TestPackageProvider {
      */
     UploadType testPackageUploadType
 
+    /**
+     * returns the upload type for the test spec file
+     */
+    UploadType testSpecUploadType
+
     File testPackage = null
 
     void tests(File val) { testPackage = val }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,1 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Thu May 21 02:18:41 IST 2020
+sdk.dir=/Users/gnand/Library/Android/sdk


### PR DESCRIPTION
Notes
PROBLEM STATEMENT:
In certain situations, consumers prioritize obtaining faster test execution results over running the same set of tests across different devices.

SOLUTION:
This change aims to tackle the aforementioned issue by introducing additional arguments for users, namely splitTestsAcrossDevices and testSpecFiles (under DeviceState). With this enhancement, the configuration will be modified as follows: [Rephrase the configuration example based on the provided information.]

 devicefarm {

        // Required. The Project must already exist. You can create a project in the AWS console.
        projectName "EspressoTests" // required: Must already exist.

        // Optional. Defaults to "Top Devices"
        devicePool "AOSP Devices"

        // Optional. Default is 150 minutes
        executionTimeoutMinutes 20

        // Optional. Set to "off" if you want to disable device video recording during a run. Default is "on"
        videoRecording "on"

        // Optional. Set to "off" if you want to disable device performance monitoring during a run. Default is "on"
        performanceMonitoring "on"

        // Required. You must specify either accessKey and secretKey OR roleArn. roleArn takes precedence.
        authentication {
            roleArn "xxxx"
        }

        // Optional block. Radios default to 'on' state, all parameters are optional
        devicestate {
            extraDataZipFile null // or ‘null’ if you have no extra data. Default is null.
            auxiliaryApps files(file("src/androidTest/auxiliaryApps/orchestrator-1.2.0.apk"),
                    file("src/androidTest/auxiliaryApps/test-services-1.2.0.apk"),
                    file("src/androidTest/auxiliaryApps/CDPAutomationHelperApp.apk")) // or ‘files()’ if you have no auxiliary apps. Default is an empty list.
            testSpecFiles files(file("src/androidTest/yaml/EURegionNewUserTests.yml"),
                    file("src/androidTest/yaml/Core_Playback_People_Places_Tests.yml"),
                    file("src/androidTest/yaml/JPRegionNewUserTests.yml"),
                    file("src/androidTest/yaml/NewUserScenarios.yml"))// or ‘files()’ if you have no auxiliary apps. Default is an empty list.
            wifi "on"
            bluetooth "off"
            gps "off"
            nfc "on"
            latitude 47.6204 // default
            longitude -122.3491 // default
        }

        testShardingEnabled true

        // Instrumentation
        instrumentation {
            // Optional. See the AWS Developer docs for filter rules
        }
    }

In the scenario where the user has multiple devices in the device pool, the updated implementation aims to create separate runs for each testSpec File provided by the user. As a result, the user will observe four different runs in the given example. However, it is important to note that the responsibility of parsing the overall test runs and managing the results will still lie with the user. This change is intended to enhance the speed of obtaining test results, empowering the user to implement their own mechanism for parsing and managing the multiple test runs.

PROBLEM STATEMENT 2:
We are facing nullPointerException for accessKey even when we provide roleArn.

SOLUTION:
The updated version of DeviceFarmClientFactory now allows users to provide only the roleArn, and it will automatically fetch the necessary credentials and create an AWSDeviceFarm client for the plugin, ensuring proper functionality.

Testing
Verified the changes in device farm